### PR TITLE
[BC-2339] fix: returns the actual result for creating aws queues and topics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,13 @@ COPY . /app
 
 RUN mix do local.hex --force, local.rebar --force, deps.get
 
+# DEV
+FROM base AS dev
+
+ENV EX_AWS_HOST="localstack"
+
+RUN apk add --update --no-cache curl
+
 # TEST
 FROM base as test
 ENV MIX_ENV=test

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -7,12 +7,12 @@ config :ex_aws,
 
 config :ex_aws, :sns,
   scheme: "http://",
-  host: "localhost",
+  host: System.get_env("EX_AWS_HOST", "localhost"),
   port: 4566
 
 config :ex_aws, :sqs,
   scheme: "http://",
-  host: "localhost",
+  host: System.get_env("EX_AWS_HOST", "localhost"),
   port: 4566
 
 config :ex_aws_configurator,

--- a/config/test.exs
+++ b/config/test.exs
@@ -7,12 +7,12 @@ config :ex_aws,
 
 config :ex_aws, :sns,
   scheme: "http://",
-  host: "localhost",
+  host: System.get_env("EX_AWS_HOST", "localhost"),
   port: 4566
 
 config :ex_aws, :sqs,
   scheme: "http://",
-  host: "localhost",
+  host: System.get_env("EX_AWS_HOST", "localhost"),
   port: 4566
 
 config :ex_aws_configurator,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,14 @@ services:
       - "4571:4571"
     environment:
       - SERVICES=sns,sqs
+
+  lib:
+    container_name: ex_aws_configurator_lib
+    depends_on:
+      - localstack
+    volumes:
+      - .:/app
+    build:
+      context: .
+      target: dev
+    command: tail -f /dev/null

--- a/lib/ex_aws_configurator/exceptions.ex
+++ b/lib/ex_aws_configurator/exceptions.ex
@@ -9,3 +9,15 @@ defmodule ExAwsConfigurator.NoResultsError do
     "not found any configuration with key #{name}"
   end
 end
+
+defmodule ExAwsConfigurator.SetupError do
+  defexception [:type, :message]
+
+  def message(%{type: :topics}),
+    do:
+      "something went wrong when creating the topics, ensure that the credentials have the necessary permissions to perform this operation"
+
+  def message(%{type: :queues}),
+    do:
+      "something went wrong when creating the queues, ensure that the credentials have the necessary permissions to perform this operation in addition to being able to subscribe to topics"
+end

--- a/lib/ex_aws_configurator/sqs.ex
+++ b/lib/ex_aws_configurator/sqs.ex
@@ -95,7 +95,25 @@ defmodule ExAwsConfigurator.SQS do
     }
     """)
 
-    create_queue_on_sqs(full_name, queue, tags)
+    queue_creation_result = create_queue_on_sqs(full_name, queue, tags)
+
+    case queue_creation_result do
+      {:ok, _} ->
+        Logger.info(~s"""
+        \n\n  #{IO.ANSI.green()}Queue #{full_name} created successfully on #{queue.region}#{
+          IO.ANSI.reset()
+        }
+        """)
+
+      {:error, term} ->
+        Logger.error(~s"""
+        \n\n  #{IO.ANSI.red()}Error creating queue #{full_name} on #{queue.region}, reason: #{
+          inspect(term)
+        }#{IO.ANSI.reset()}
+        """)
+    end
+
+    queue_creation_result
   end
 
   @doc """

--- a/test/ex_aws_configurator/sns_test.exs
+++ b/test/ex_aws_configurator/sns_test.exs
@@ -1,6 +1,8 @@
 defmodule ExAwsConfigurator.SNSTest do
   use ExAwsConfigurator.Case
 
+  import ExUnit.CaptureLog
+
   alias ExAwsConfigurator.SNS
 
   doctest SNS
@@ -10,6 +12,7 @@ defmodule ExAwsConfigurator.SNSTest do
   setup do
     add_topic_to_config(build(:topic_config, name: :topic_name))
     add_topic_to_config(%{topic_min_config: %{}})
+    add_topic_to_config(%{:"!nv@l!d-N@me" => %{}})
 
     SNS.create_topic(:topic_min_config)
     SNS.create_topic(:topic_name)
@@ -19,11 +22,21 @@ defmodule ExAwsConfigurator.SNSTest do
 
   describe "create_topic/1" do
     test "create topic when receive a atom with correct configuration" do
-      assert {:ok, %{status_code: 200}} = SNS.create_topic(:topic_name)
+      assert capture_log(fn ->
+               assert {:ok, %{status_code: 200}} = SNS.create_topic(:topic_name)
+             end) =~ "created successfully"
     end
 
     test "create topic with min attributes" do
-      assert {:ok, %{status_code: 200}} = SNS.create_topic(:topic_min_config)
+      assert capture_log(fn ->
+               assert {:ok, %{status_code: 200}} = SNS.create_topic(:topic_min_config)
+             end) =~ "created successfully"
+    end
+
+    test "do not create an invalid topic" do
+      assert capture_log(fn ->
+               assert {:error, _} = SNS.create_topic(:"!nv@l!d-N@me")
+             end) =~ "Error creating topic"
     end
 
     test "raise when tries to create a topic without configuration" do


### PR DESCRIPTION
**Basicamente**:

**Motivação**:
- [x] Hoje, a _lib_ não retorna um erro, ou algo relvante ao rodar o _setup_ pelo fato de não lidar com o retorno das funcões `ExAwsConfigurator.SNS.create_topic()` e `ExAwsConfigurator.SQS.create_queue()`

**Esperado**:
A ideia é poder ter uma visibilidade maior de algo que possa dar errado e também que possa ser _blockante_ nas _pipelines_ evitando que algum artefato chegue em produção  sem ter passado pelo devido processo de setup.

Algo que estava acontecendo:
1. Projeto **A** roda pipeline, e nada de inesperado acontece durante o _setup_ da _AWS_ na pipeline.
2. Projeto **A** passa a tentar usar o tópico que era para ter sido criado, mas ele não existe.

**Objetivo**:
A ideia não é quebrar nada que exista hoje, por isso mesmo por mais que tenha incrementado os logs nos devidos lugares, adicionei um `setup!()` para que quem esteja com os mesmo problemas possa usar.

**Exemplo**:
```bash
iex(1)> ExAwsConfigurator.setup!()
18:51:00.606 [info]  Creating topic prefix_test_an_topic on us-east-1
18:51:00.668 [info]  Topic prefix_test_an_topic created successfully on us-east-1
18:51:00.668 [info]  Creating topic another_topic on sa-east-1
18:51:00.672 [info]  Topic another_topic created successfully on sa-east-1
18:51:00.679 [info]  

  Creating queue prefix_test_an_queue on us-east-1
    Attributes:
      > content_based_deduplication: 
      > delay_seconds: 0
      > fifo_queue: 
      > maximum_message_size: 262144
      > message_retention_period: 1209600
      > receive_message_wait_time_seconds: 0
      > visibility_timeout: 60
    Options:
      > dead_letter_queue: true
      > dead_letter_queue_suffix: _failures
      > max_receive_count: 7

18:51:00.683 [info]  

  Queue prefix_test_an_queue created successfully on us-east-1

18:51:00.683 [info]  Subscribe queue prefix_test_an_queue to topic prefix_test_an_topic
18:51:00.687 [info]  Subscribe queue prefix_test_an_queue to topic another_topic
18:51:00.694 [info]  

  Creating queue prefix_test_another_queue on us-east-1
    Attributes:
      > content_based_deduplication: 
      > delay_seconds: 0
      > fifo_queue: 
      > maximum_message_size: 262144
      > message_retention_period: 1209600
      > receive_message_wait_time_seconds: 0
      > visibility_timeout: 60
    Options:
      > dead_letter_queue: true
      > dead_letter_queue_suffix: _failures
      > max_receive_count: 7

** (ExAwsConfigurator.SetupError) something went wrong when creating the queues, ensure that the credentials have the necessary permissions to perform this operation in addition to being able to subscribe to topics
    (ex_aws_configurator 1.4.0) lib/ex_aws_configurator.ex:76: ExAwsConfigurator.setup!/0
18:51:00.705 [error] 

  Error creating queue prefix_test_another_queue on us-east-1, reason: {:http_error, 400, %{code: "QueueAlreadyExists", detail: "", message: "A queue already exists with the same name and a different value for attribute RedrivePolicy", request_id: "cf645f75-ca04-4251-84c5-3a7eb9332d0a", type: "Sender"}}

18:51:00.705 [error] Some queues was not created: [:another_queue]
```

Quanto as outras alterações, _Dockerfile_, _docker-compsoe.yml_, _config/*_, se não acharem pertinente, eu removo. Foi apenas por necessidade aqui.
